### PR TITLE
[SC-4518] Pin Go 1.26.6 so the stdlib CI scans is a patched one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gethuman-sh/human
 
-go 1.26.5
+go 1.26.6
 
 require (
 	fyne.io/systray v1.12.2


### PR DESCRIPTION
CI's security job is red on every run: `go tool govulncheck ./...` finds five reachable Go standard library vulnerabilities — GO-2026-6218 (net/url), GO-2026-6090 (crypto/tls), GO-2026-6089 (net/http), GO-2026-5972 (encoding/asn1), GO-2026-5026 (idna via net/http). All five are fixed in go1.26.6.

Every job resolves its toolchain from go.mod through setup-go's `go-version-file`, so the `go` directive is the only knob. Bumped 1.26.5 → 1.26.6; govulncheck reports nothing reachable.

Failing run: https://github.com/gethuman-sh/human/actions/runs/32117720149