### PR TITLE
[SC-4595] [SC-4596] Make agent containers usable on a worktree project and a macOS host

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -112,7 +112,7 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 		return Meta{}, err
 	}
 
-	dcMeta, err := m.startDevcontainer(ctx, containerName, configDir, workspace, worktreeGitDir(projectDir, worktree), opts.Rebuild)
+	dcMeta, err := m.startDevcontainer(ctx, containerName, configDir, workspace, worktreeGitDir(ctx, projectDir, worktree), opts.Rebuild)
 	if err != nil {
 		removeWorktreeOnFailure()
 		// A failure here is most often an unreachable Docker engine. Surface an
@@ -161,13 +161,29 @@ func (m *Manager) Start(ctx context.Context, opts StartOpts) (Meta, error) {
 	return meta, nil
 }
 
-// worktreeGitDir names the parent repo's .git for a worktree workspace — a
-// worktree's .git FILE points there by absolute host path, so the container
-// must bind it alongside (ticket 482). Shared-checkout runs (no worktree)
-// carry their .git inside the source mount and need nothing extra.
-func worktreeGitDir(projectDir, worktree string) string {
+// worktreeGitDir names the git directory a worktree workspace must have bound
+// alongside it — a worktree's .git FILE points at the object store by absolute
+// host path, so the container needs that path to exist (ticket 482).
+// Shared-checkout runs (no worktree) carry their .git inside the source mount
+// and need nothing extra.
+//
+// The answer is the COMMON git dir, not <projectDir>/.git. The two coincide
+// only while the project dir is a main checkout; when the project dir is itself
+// a linked worktree — a daemon registered on one, which is the ordinary way to
+// run several projects off one repo — <projectDir>/.git is a pointer file, and
+// binding it gave the container a pointer to an unmounted path. Every git
+// command then answered "not a git repository", and the board recorded the
+// stage failure as the ticket's rather than the container's (SC-4595).
+//
+// Falling back to the join keeps a launch that git cannot answer for working
+// exactly as it did before, rather than dropping the mount entirely and
+// breaking the main-checkout case too.
+func worktreeGitDir(ctx context.Context, projectDir, worktree string) string {
 	if worktree == "" {
 		return ""
+	}
+	if common, err := gitrepo.CommonGitDir(ctx, projectDir); err == nil {
+		return common
 	}
 	return filepath.Join(projectDir, ".git")
 }
@@ -177,11 +193,11 @@ func resolveDirectories(opts StartOpts) (workspace, configDir string) {
 	if workspace == "" {
 		workspace = "."
 	}
-	// Must be absolute: it becomes projectDir, which worktreeGitDir joins
-	// with ".git" to produce a Docker bind-mount source — Docker rejects a
-	// relative mount path outright ("invalid mount path: '.git' must be
-	// absolute") whenever a caller (e.g. the CLI's default "." workspace)
-	// leaves it relative.
+	// Must be absolute: it becomes projectDir, which worktreeGitDir turns into
+	// a Docker bind-mount source — Docker rejects a relative mount path
+	// outright ("invalid mount path: '.git' must be absolute") whenever a
+	// caller (e.g. the CLI's default "." workspace) leaves it relative, and the
+	// fallback join is exactly such a path.
 	if abs, err := filepath.Abs(workspace); err == nil {
 		workspace = abs
 	}

--- a/internal/agent/manager_gitdir_test.go
+++ b/internal/agent/manager_gitdir_test.go
@@ -1,0 +1,121 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gethuman-sh/human/errors"
+	"github.com/gethuman-sh/human/internal/gitrepo"
+)
+
+// realPath resolves the symlinks a temp dir carries on macOS (/var → /private/var),
+// so a path git printed and a path the test joined compare as the same place.
+func realPath(t *testing.T, p string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", p, err)
+	}
+	return resolved
+}
+
+// TestWorktreeGitDir_ProjectIsItselfAWorktree is the SC-4595 regression: a
+// daemon registered on a linked worktree launched every run with that
+// worktree's .git POINTER FILE as the container's only git bind, so the run
+// worktree's own pointer led to an unmounted path and every git command in the
+// container answered "not a git repository". The bind must be the common dir —
+// a real directory, holding the metadata of both worktrees.
+func TestWorktreeGitDir_ProjectIsItselfAWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	root := t.TempDir()
+
+	main := filepath.Join(root, "main")
+	runGitM(t, root, "init", "-b", "main", main)
+	writeFileT(t, filepath.Join(main, "a.txt"), "one\n")
+	runGitM(t, main, "add", "a.txt")
+	runGitM(t, main, "commit", "-m", "base")
+
+	// The registered project: a linked worktree of main, exactly the shape the
+	// daemon runs on when several projects share one repo.
+	project := filepath.Join(root, "project")
+	runGitM(t, main, "worktree", "add", "--detach", project)
+
+	// The per-run worktree, cut from the project dir the way mountSourceForRun
+	// cuts it. Its .git points into the COMMON dir, not into the project dir.
+	run := filepath.Join(root, "run")
+	runGitM(t, project, "worktree", "add", "--detach", run)
+
+	got := worktreeGitDir(context.Background(), project, run)
+
+	wantCommon := realPath(t, filepath.Join(main, ".git"))
+	if realPath(t, got) != wantCommon {
+		t.Errorf("gitDir = %q, want the common dir %q", got, wantCommon)
+	}
+	info, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat %q: %v", got, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("gitDir %q is not a directory — a pointer file mounts nothing", got)
+	}
+	// The bind has to cover what the run worktree's pointer actually names,
+	// which is the whole point of preferring the common dir.
+	pointer, err := os.ReadFile(filepath.Join(run, ".git")) // #nosec G304 -- test-owned temp path
+	if err != nil {
+		t.Fatalf("reading run worktree pointer: %v", err)
+	}
+	target := realPath(t, string(pointer[len("gitdir: "):len(pointer)-1]))
+	if rel, relErr := filepath.Rel(realPath(t, got), target); relErr != nil || rel == ".." || filepath.IsAbs(rel) {
+		t.Errorf("run worktree gitdir %q is not inside the bind %q", target, got)
+	}
+}
+
+// TestWorktreeGitDir_MainCheckoutUnchanged pins the case that already worked:
+// a project dir that is a main checkout binds its own .git, as before.
+func TestWorktreeGitDir_MainCheckoutUnchanged(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	root := t.TempDir()
+
+	project := filepath.Join(root, "project")
+	runGitM(t, root, "init", "-b", "main", project)
+	writeFileT(t, filepath.Join(project, "a.txt"), "one\n")
+	runGitM(t, project, "add", "a.txt")
+	runGitM(t, project, "commit", "-m", "base")
+
+	run := filepath.Join(root, "run")
+	runGitM(t, project, "worktree", "add", "--detach", run)
+
+	got := worktreeGitDir(context.Background(), project, run)
+	if realPath(t, got) != realPath(t, filepath.Join(project, ".git")) {
+		t.Errorf("gitDir = %q, want %q", got, filepath.Join(project, ".git"))
+	}
+}
+
+func TestWorktreeGitDir_NoWorktreeBindsNothing(t *testing.T) {
+	if got := worktreeGitDir(context.Background(), "/some/project", ""); got != "" {
+		t.Errorf("gitDir = %q, want empty for a shared-checkout run", got)
+	}
+}
+
+// TestWorktreeGitDir_FallsBackWhenGitCannotAnswer keeps a launch git cannot
+// answer for behaving as it did before the common-dir resolution existed,
+// rather than dropping the mount and breaking the main-checkout case too.
+func TestWorktreeGitDir_FallsBackWhenGitCannotAnswer(t *testing.T) {
+	prev := gitrepo.CommonGitDir
+	gitrepo.CommonGitDir = func(_ context.Context, _ string) (string, error) {
+		return "", errors.WithDetails("git unavailable")
+	}
+	t.Cleanup(func() { gitrepo.CommonGitDir = prev })
+
+	got := worktreeGitDir(context.Background(), "/some/project", "/some/run")
+	if got != filepath.Join("/some/project", ".git") {
+		t.Errorf("gitDir = %q, want the joined fallback", got)
+	}
+}

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -1,6 +1,7 @@
 package devcontainer
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -344,8 +345,13 @@ func (m *Manager) buildCreateOptions(cfg *DevcontainerConfig, projectDir, config
 	}
 	binds = append(binds, Bind(claudeJSON, targetHome+"/.claude.json"))
 
-	// Mount host human binary so the container always uses the same version.
-	if humanBin, exeErr := os.Executable(); exeErr == nil {
+	// Mount host human binary so the container always uses the same version —
+	// but only one the container can actually execute. The image ships a linux
+	// human at this path already, so binding a macOS build over it does not pin
+	// a version, it replaces a working binary with one that answers "Exec format
+	// error" — and takes the lifecycle hooks with it, since postStartCommand
+	// installs the proxy CA by running human (SC-4596).
+	if humanBin, exeErr := os.Executable(); exeErr == nil && runsInContainer(humanBin) {
 		binds = append(binds, Bind(humanBin, "/usr/local/bin/human").ReadOnly())
 	}
 
@@ -648,4 +654,32 @@ func (m *Manager) prepareCacheVolumes(ctx context.Context, containerID, remoteUs
 		return err
 	}
 	return execInContainer(ctx, m.Docker, containerID, "root", append([]string{"chown", remoteUser}, paths...), nil, m.Logger)
+}
+
+// elfMagic is the first four bytes of every ELF executable — the format a linux
+// container can run.
+var elfMagic = []byte{0x7f, 'E', 'L', 'F'}
+
+// runsInContainer reports whether the host binary at path is in the container's
+// executable format, so a bind of it replaces the image's binary with something
+// that still runs.
+//
+// Format, not architecture: an ELF built for another CPU than the container's
+// still fails, and detecting that means reading the ELF header's machine field
+// for a mapping to Docker's platform strings. The case this exists for is the
+// whole-format mismatch a macOS or Windows host produces, which is one read of
+// four bytes. An unreadable binary answers false — the image's own binary is a
+// working fallback, and a failed launch is not.
+func runsInContainer(path string) bool {
+	f, err := os.Open(path) // #nosec G304 -- path is this process's own executable
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	header := make([]byte, len(elfMagic))
+	if _, err := io.ReadFull(f, header); err != nil {
+		return false
+	}
+	return bytes.Equal(header, elfMagic)
 }

--- a/internal/devcontainer/manager.go
+++ b/internal/devcontainer/manager.go
@@ -30,12 +30,14 @@ type UpOptions struct {
 	Out           io.Writer
 	ContainerName string // override container name (default: derived from project dir)
 	SourceDir     string // override mount source (default: same as ProjectDir)
-	// GitDir is the parent repo's .git directory to bind at its host-identical
-	// path when SourceDir is a git worktree: a worktree's .git FILE references
-	// the parent by absolute host path, so without this bind every in-container
-	// git command fails with "not a git repository" (ticket 482). Empty for
-	// shared-checkout and non-git workspaces, whose .git travels with the
-	// source mount itself.
+	// GitDir is the repository's common .git directory to bind at its
+	// host-identical path when SourceDir is a git worktree: a worktree's .git
+	// FILE references the object store by absolute host path, so without this
+	// bind every in-container git command fails with "not a git repository"
+	// (ticket 482). The COMMON dir, because a worktree of a worktree resolves
+	// through the same one and a per-worktree .git is only a pointer to it
+	// (SC-4595). Empty for shared-checkout and non-git workspaces, whose .git
+	// travels with the source mount itself.
 	GitDir string
 
 	// cacheVolumes is populated by Up from the project's .humanconfig caches

--- a/internal/devcontainer/manager_hostbinary_test.go
+++ b/internal/devcontainer/manager_hostbinary_test.go
@@ -1,0 +1,46 @@
+package devcontainer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRunsInContainer_FormatDecides is the SC-4596 regression: the host binary
+// is bound over the image's own only when the container can execute it. A
+// macOS build masking a working linux one cost every in-container `human`
+// call, the proxy CA install, and with it all outbound https.
+func TestRunsInContainer_FormatDecides(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name    string
+		content []byte
+		want    bool
+	}{
+		{"elf", append([]byte{0x7f, 'E', 'L', 'F'}, 0x02, 0x01, 0x01, 0x00), true},
+		{"mach-o 64-bit", []byte{0xcf, 0xfa, 0xed, 0xfe, 0x0c, 0x00, 0x00, 0x01}, false},
+		{"pe", []byte{'M', 'Z', 0x90, 0x00}, false},
+		{"shorter than the magic", []byte{0x7f, 'E'}, false},
+		{"empty", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name)
+			if err := os.WriteFile(path, tc.content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := runsInContainer(path); got != tc.want {
+				t.Errorf("runsInContainer(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// A binary that cannot be read leaves the image's own in place rather than
+// failing the launch.
+func TestRunsInContainer_UnreadableBinary(t *testing.T) {
+	if runsInContainer(filepath.Join(t.TempDir(), "absent")) {
+		t.Error("runsInContainer = true for a missing binary, want false")
+	}
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -320,6 +320,31 @@ var BranchReachable = func(ctx context.Context, dir, branch string) bool {
 	return BranchReachability(ctx, dir, branch) == ReachabilityPresent
 }
 
+// CommonGitDir returns the absolute path of the repository's COMMON git
+// directory for dir — the object store itself, shared by the main checkout and
+// every linked worktree (running `git -C <dir> rev-parse --path-format=absolute
+// --git-common-dir`).
+//
+// It is not `<dir>/.git`, and the difference is the whole reason it exists. That
+// join answers correctly only for a main checkout; in a linked worktree `.git`
+// is a pointer FILE naming a path outside the tree, so a caller that binds it
+// into a container hands over a pointer to something that is not there
+// (SC-4595). The common dir is the same directory in both topologies, and every
+// worktree's metadata lives under it, so binding it once serves them all.
+//
+// Package var so callers can stub git access in tests.
+var CommonGitDir = func(ctx context.Context, dir string) (string, error) {
+	out, err := runner(ctx, "git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return "", errors.WrapWithDetails(err, "resolving common git dir", "dir", dir)
+	}
+	common := strings.TrimSpace(string(out))
+	if common == "" {
+		return "", errors.WithDetails("git named no common dir", "dir", dir)
+	}
+	return common, nil
+}
+
 // WorktreeAdd creates a detached private worktree at worktreePath rooted at base
 // (running `git -C <repoDir> worktree add --detach <worktreePath> <base>`). The
 // worktree shares repoDir's object DB, so branches created inside it are visible

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -842,3 +842,48 @@ func TestCommitsForRev_anchorsAtGivenRev(t *testing.T) {
 		t.Errorf("args = %v, want rev anchor feat/branch", gotArgs)
 	}
 }
+
+func TestCommonGitDir_argvAndTrim(t *testing.T) {
+	var gotArgs []string
+	withRunner(t, func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotArgs = append([]string{name}, args...)
+		return []byte("/repo/.git\n"), nil
+	})
+
+	common, err := CommonGitDir(context.Background(), "/repo/worktrees/one")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if common != "/repo/.git" {
+		t.Errorf("common = %q, want trimmed common dir", common)
+	}
+	// --path-format=absolute is what makes the answer usable as a mount source:
+	// without it git answers ".git" from a main checkout's own top level.
+	want := []string{"git", "-C", "/repo/worktrees/one", "rev-parse", "--path-format=absolute", "--git-common-dir"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, gotArgs[i], want[i])
+		}
+	}
+}
+
+func TestCommonGitDir_commandError(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("exit status 128")
+	})
+	if _, err := CommonGitDir(context.Background(), "/not/a/repo"); err == nil {
+		t.Fatal("expected error when git fails")
+	}
+}
+
+func TestCommonGitDir_emptyOutput(t *testing.T) {
+	withRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("  \n"), nil
+	})
+	if _, err := CommonGitDir(context.Background(), "/repo"); err == nil {
+		t.Fatal("expected error when git names no common dir")
+	}
+}


### PR DESCRIPTION
Two mounts were wrong for the same launch, and together they stopped every board run on this host.

**SC-4595 — the git bind was a pointer file.** `worktreeGitDir` bound `<projectDir>/.git`, which is the object store only when the project dir is a main checkout. The daemon here is registered on a linked worktree, so it bound a 77-byte pointer naming a path on no mount; every in-container git command answered "not a git repository". SC-4520 spent its whole retry budget there: 12 launches, 16 identical `[human:implementation-failed]` markers, no code changed. The bind is now the common git dir, which is the same directory in both topologies and holds every worktree's metadata.

**SC-4596 — the human bind masked a working binary.** The image ships a linux `human` at `/usr/local/bin/human`; the host's macOS build was bound over it, so `human` answered "Exec format error" — including inside `postStartCommand`, which is what installs the proxy CA. The bind now requires an ELF host binary.

Verified end to end against the real registered project (`.claude/worktrees/branch-sync-status-fa1137`), launching a container with the built binary:

```
--- human:    human version 0.20.0 (9761f4b)
--- git-dir:  /Users/andre/Projects/human/.git/worktrees/gitmount-check-94ef38e6909c
--- head:     748ca08 Merge pull request #503 ...
```

Both regressions are pinned by tests that fail on the old behaviour: a real-git test building main → linked worktree → run worktree, and a format table for the binary gate.

`make check`: lint 0 issues, gosec/govulncheck 0, gitleaks clean, fmt clean; one pre-existing macOS-only failure, `internal/claude TestTranscriptRoots_dropsNestedRoot`, red on `origin/main` (748ca08) with these changes stashed.

Still red, out of scope: the proxy allowlist in `.humanconfig.yaml` has `*.github.com`, which by design does not match the apex — `https://github.com` is refused in-container (`curl` → 000) while `api.github.com` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)