### PR TITLE
[SC-4686] Report a Claude credential store that was never signed in

### DIFF
--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -165,48 +165,97 @@ type claudeCreds struct {
 	} `json:"claudeAiOauth"`
 }
 
-// checkClaudeAuth catches SC-912: a daemon whose Claude OAuth session expired
-// still competes for board work and fails every pickup ~15s in at agent auth.
+// claudeStoreState is what one project's host credential store says about its
+// Claude session. Everything the probe cannot judge collapses to claudeStoreOK:
+// the check blames a project only on positive evidence.
+type claudeStoreState int
+
+const (
+	claudeStoreOK      claudeStoreState = iota // usable, or unjudgeable and therefore not blamed
+	claudeStoreAbsent                          // no store at all — never signed in
+	claudeStoreExpired                         // signed in once, session dead and unrefreshable
+)
+
+// claudeStoreAt classifies one project's host credential store.
+//
+// Absence and schema drift are different faults and get different verdicts. A
+// file that does not exist is a definite, checkable state with a known remedy —
+// nobody ever signed in — so it is reported. Everything else the probe cannot
+// read or cannot parse is unjudgeable: a path or schema mismatch must never
+// block a daemon whose Claude is in fact authenticated, so it degrades to OK
+// (SC-4686 for the split; SC-912 for the fail-open it preserves).
+//
+// An empty claudeAiOauth block stays OK deliberately. It is indistinguishable
+// from schema drift — a renamed field leaves the block looking empty too — and
+// the fields read here are too few to tell the two apart.
+func claudeStoreAt(path string, nowMS int64) claudeStoreState {
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is built from the daemon's own project registry dirs, not external input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return claudeStoreAbsent
+		}
+		return claudeStoreOK // fail-open: unreadable for some other reason → no evidence either way
+	}
+	var creds claudeCreds
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		return claudeStoreOK // fail-open: schema drift must not block launches
+	}
+	if creds.ClaudeAiOauth.ExpiresAt == 0 {
+		return claudeStoreOK // fail-open: no expiry recorded → cannot judge freshness
+	}
+	// An expired ACCESS token with a refresh token present is the normal resting
+	// state between agent runs — the next launched Claude refreshes it silently.
+	// Only a session that can no longer refresh is dead.
+	if creds.ClaudeAiOauth.RefreshToken != "" {
+		return claudeStoreOK
+	}
+	if creds.ClaudeAiOauth.ExpiresAt <= nowMS {
+		return claudeStoreExpired
+	}
+	return claudeStoreOK
+}
+
+// checkClaudeAuth catches the two states in which every launched agent dies at
+// Claude auth while the daemon keeps competing for board work: a session that
+// expired past refreshing (SC-912, ~15s deaths) and a credential store that was
+// never signed in at all (SC-4686, ~7s deaths with "Not logged in · Please run
+// /login"). Both are launch-critical, so reporting them refuses the pickup
+// instead of spending a stage's retry budget on a container that cannot work.
+//
 // The in-container Claude store is bind-mounted from the host at
 // <entry.Dir>/.devcontainer/claude/ → ~/.claude, so the probe reads the host
-// copy of .credentials.json. It is fail-open by design: only a present,
-// parseable session that is past its expiresAt AND has no refresh token is a
-// failure — with a refresh token the next launched Claude renews the access
-// token itself, so an expired access token between runs is healthy. An absent,
-// unreadable, unparseable, or expiresAt-less file degrades to pre-fix behaviour
-// (ok=true) so a path/schema mismatch never blocks a healthy daemon.
+// copy of .credentials.json. claudeStoreAt holds which states are judgeable.
 func checkClaudeAuth(reg *daemon.ProjectRegistry) (bool, string) {
 	nowMS := time.Now().UnixMilli()
-	var expired []string
+	var absent, expired []string
 	for _, entry := range reg.Entries() {
-		path := filepath.Join(entry.Dir, ".devcontainer", "claude", ".credentials.json")
-		raw, err := os.ReadFile(path) // #nosec G304 -- path is built from the daemon's own project registry dirs, not external input
-		if err != nil {
-			continue // fail-open: no host store here, nothing to verify
-		}
-		var creds claudeCreds
-		if err := json.Unmarshal(raw, &creds); err != nil {
-			continue // fail-open: schema drift must not block launches
-		}
-		if creds.ClaudeAiOauth.ExpiresAt == 0 {
-			continue // fail-open: no expiry recorded → cannot judge freshness
-		}
-		// An expired ACCESS token with a refresh token present is the normal
-		// resting state between agent runs — the next launched Claude refreshes
-		// it silently. Only a session that can no longer refresh is dead.
-		if creds.ClaudeAiOauth.RefreshToken != "" {
-			continue
-		}
-		if creds.ClaudeAiOauth.ExpiresAt <= nowMS {
+		switch claudeStoreAt(filepath.Join(entry.Dir, ".devcontainer", "claude", ".credentials.json"), nowMS) {
+		case claudeStoreAbsent:
+			absent = append(absent, entry.Dir)
+		case claudeStoreExpired:
 			expired = append(expired, entry.Dir)
+		case claudeStoreOK:
 		}
 	}
+	var faults []string
+	if len(absent) > 0 {
+		faults = append(faults, "no Claude credential store for "+strings.Join(absent, ", "))
+	}
 	if len(expired) > 0 {
-		return false, "Claude session expired for " + strings.Join(expired, ", ") +
-			" — sign in to the project's container credential store: run 'human agent start reauth --interactive' in the project, /login inside it, then 'human agent stop reauth'; the daemon resumes picking up board work once the session is fresh"
+		faults = append(faults, "Claude session expired for "+strings.Join(expired, ", "))
+	}
+	if len(faults) > 0 {
+		return false, strings.Join(faults, "; ") + " — " + claudeReauthRemedy
 	}
 	return true, "session valid"
 }
+
+// claudeReauthRemedy is the one procedure that fixes every state
+// checkClaudeAuth reports, so both faults print it from one place.
+const claudeReauthRemedy = "sign in to the project's container credential store: " +
+	"run 'human agent start reauth --interactive' in the project, /login inside it, " +
+	"then 'human agent stop reauth'; " +
+	"the daemon resumes picking up board work once the session is fresh"
 
 // checkCodenavIndex reports the shared code-navigation index's coverage. A
 // still-warming project is reported ok=true (the daemon's background loop will

--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -125,10 +125,18 @@ func checkDocker(ctx context.Context) (bool, string) {
 
 // checkCACert catches ticket 428's failure mode: a present-but-unparseable
 // CA silently breaks in-container TLS and hook delivery for every agent. An
-// absent file is fine — the daemon generates it on first proxy use.
+// absent file is fine — the daemon generates it on first proxy use — but only
+// absence is: a stat that fails for any other reason means the daemon cannot
+// tell whether the CA it mounts into every container is usable, and reporting
+// that as "not yet generated" states the one thing known to be untrue
+// (SC-4686, the same absent-vs-unreadable conflation as checkClaudeAuth).
 func checkCACert(path string) (bool, string) {
 	if _, err := os.Stat(path); err != nil {
-		return true, "not yet generated"
+		if os.IsNotExist(err) {
+			return true, "not yet generated"
+		}
+		return false, path + " cannot be read: " + err.Error() +
+			" — fix its permissions, or delete it and restart the daemon to regenerate"
 	}
 	if !devcontainer.IsValidCACertFile(path) {
 		return false, path + " exists but is not a valid PEM certificate — delete it and restart the daemon to regenerate"

--- a/cmd/cmddaemon/doctor_checks.go
+++ b/cmd/cmddaemon/doctor_checks.go
@@ -250,11 +250,15 @@ func checkClaudeAuth(reg *daemon.ProjectRegistry) (bool, string) {
 	return true, "session valid"
 }
 
-// claudeReauthRemedy is the one procedure that fixes every state
-// checkClaudeAuth reports, so both faults print it from one place.
+// claudeReauthRemedy is the one procedure that fixes every state checkClaudeAuth
+// reports. It stops at /login on purpose: the daemon tears an interactive agent
+// down on its run-end hook (daemon.cleanupAfterExit), so a documented trailing
+// 'human agent stop reauth' always lost the race and greeted the user with
+// "reading agent metadata: ... no such file or directory" — on the exact
+// procedure someone reaches for when their pipeline is already broken.
 const claudeReauthRemedy = "sign in to the project's container credential store: " +
-	"run 'human agent start reauth --interactive' in the project, /login inside it, " +
-	"then 'human agent stop reauth'; " +
+	"run 'human agent start reauth --interactive' in the project and /login inside it, " +
+	"then exit the session (the daemon cleans the agent up); " +
 	"the daemon resumes picking up board work once the session is fresh"
 
 // checkCodenavIndex reports the shared code-navigation index's coverage. A

--- a/cmd/cmddaemon/doctor_checks_test.go
+++ b/cmd/cmddaemon/doctor_checks_test.go
@@ -109,17 +109,52 @@ func TestCheckClaudeAuth_valid(t *testing.T) {
 	assert.Equal(t, "session valid", detail)
 }
 
-// No host credential store → fail-open (ok=true): a path/schema mismatch must
-// degrade to pre-fix behaviour, never block a healthy daemon.
-func TestCheckClaudeAuth_absentStoreFailsOpen(t *testing.T) {
-	reg, err := daemon.NewProjectRegistry([]string{t.TempDir()})
+// A registered project with no host credential store at all is the SC-4686
+// failure: every stage agent dies ~7s in at "Not logged in", while doctor said
+// "session valid". Absence is not schema drift — it is a definite state with a
+// known remedy, so it goes red and names it.
+func TestCheckClaudeAuth_absentStoreIsUnauthenticated(t *testing.T) {
+	dir := t.TempDir()
+	reg, err := daemon.NewProjectRegistry([]string{dir})
 	require.NoError(t, err)
-	ok, _ := checkClaudeAuth(reg)
+	ok, detail := checkClaudeAuth(reg)
+	assert.False(t, ok)
+	assert.Contains(t, detail, dir)
+	assert.Contains(t, detail, "container credential store")
+	assert.Contains(t, detail, "human agent start reauth --interactive")
+}
+
+// A store that cannot be read for a reason other than absence is unjudgeable —
+// the daemon has no evidence the session is dead — so it keeps failing open.
+// Reading a directory yields a non-NotExist error on every supported platform.
+func TestCheckClaudeAuth_unreadableStoreFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".devcontainer", "claude", ".credentials.json"), 0o755))
+	reg, err := daemon.NewProjectRegistry([]string{dir})
+	require.NoError(t, err)
+	ok, detail := checkClaudeAuth(reg)
 	assert.True(t, ok)
+	assert.Equal(t, "session valid", detail)
+}
+
+// Schema drift must never block a healthy daemon: a store whose JSON no longer
+// parses is reported ok, exactly as before SC-4686.
+func TestCheckClaudeAuth_unparseableStoreFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	credDir := filepath.Join(dir, ".devcontainer", "claude")
+	require.NoError(t, os.MkdirAll(credDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(credDir, ".credentials.json"), []byte("not json at all"), 0o600))
+	reg, err := daemon.NewProjectRegistry([]string{dir})
+	require.NoError(t, err)
+	ok, detail := checkClaudeAuth(reg)
+	assert.True(t, ok)
+	assert.Equal(t, "session valid", detail)
 }
 
 // A present credential file that records no expiry cannot be judged, so the
-// check fails open rather than blocking on an unknowable freshness.
+// check fails open rather than blocking on an unknowable freshness. This is
+// also the shape schema drift takes — a renamed field leaves the block looking
+// empty — which is why an empty block is NOT treated like an absent store.
 func TestCheckClaudeAuth_missingExpiryFailsOpen(t *testing.T) {
 	reg := claudeAuthRegistry(t, 0)
 	ok, _ := checkClaudeAuth(reg)

--- a/cmd/cmddaemon/doctor_checks_test.go
+++ b/cmd/cmddaemon/doctor_checks_test.go
@@ -78,6 +78,26 @@ func TestCheckCACert(t *testing.T) {
 	assert.Contains(t, detail, "restart the daemon to regenerate")
 }
 
+// A stat that fails for a reason other than absence must not be reported as
+// "not yet generated": the daemon cannot tell whether the CA it mounts into
+// every container is usable, and absence is the one thing it knows is untrue.
+// A path under a non-searchable directory yields a non-NotExist stat error.
+func TestCheckCACert_unreadableIsNotReportedAsAbsent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	locked := filepath.Join(t.TempDir(), "locked")
+	require.NoError(t, os.Mkdir(locked, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(locked, "ca.crt"), []byte("x"), 0o600))
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	ok, detail := checkCACert(filepath.Join(locked, "ca.crt"))
+	assert.False(t, ok)
+	assert.NotContains(t, detail, "not yet generated")
+	assert.Contains(t, detail, "cannot be read")
+}
+
 func TestCheckPersistence(t *testing.T) {
 	ok, _ := checkPersistence(doctorPersistence{stats: true, audit: true, confirms: true})
 	assert.True(t, ok)

--- a/cmd/cmddaemon/doctor_checks_test.go
+++ b/cmd/cmddaemon/doctor_checks_test.go
@@ -92,6 +92,14 @@ func TestCheckPersistence(t *testing.T) {
 	assert.Contains(t, detail, "approvals")
 }
 
+// The remedy every claude-auth fault prints must stop at /login: the daemon
+// auto-cleans an interactive agent on its run-end hook, so a trailing
+// 'human agent stop reauth' always failed with a raw metadata-path error.
+func TestClaudeReauthRemedy_doesNotDocumentAgentStop(t *testing.T) {
+	assert.Contains(t, claudeReauthRemedy, "human agent start reauth --interactive")
+	assert.NotContains(t, claudeReauthRemedy, "human agent stop reauth")
+}
+
 // A session whose expiresAt is in the past is the SC-912 failure: the check goes
 // red and names the re-authenticate fix so the daemon stops sniping board work.
 func TestCheckClaudeAuth_expired(t *testing.T) {


### PR DESCRIPTION
`human doctor` reported `✓ Claude authentication — session valid` and `all systems go` for a registered project whose container credential store did not exist — the exact state in which every board stage agent dies ~7s in with `Not logged in · Please run /login`. Doctor was green precisely when the pipeline could not run.

`checkClaudeAuth` skipped a project on any `os.ReadFile` error, so a never-signed-in store was indistinguishable from a healthy one. Since `claude-auth` is in `LaunchCriticalChecks`, a correct verdict now refuses the pickup instead of spending each stage's retry budget on a container that cannot work.

### Commits

1. **Report a store that was never signed in** — absence and schema drift become different faults. A file that does not exist is a definite, checkable state with a known remedy, so it is reported; every other read error, an unparseable body, and a missing `expiresAt` still degrade to `ok=true`, each pinned by its own test, so a path or schema mismatch never blocks a daemon whose Claude is in fact authenticated. An empty `claudeAiOauth` block stays fail-open deliberately: a renamed field leaves the block looking empty too, and the fields read here cannot tell the two apart.

2. **Stop documenting a reauth step that always fails** — the remedy ended with `human agent stop reauth`, but the daemon tears an interactive agent down on its run-end hook (`cleanupAfterExit` → `DeleteAgent`), so that step always failed with `reading agent metadata: ... no such file or directory`. Harmless, but it greeted the user with an error on the exact procedure they reach for when the pipeline is already broken — and this check now prints that remedy for the far more common never-signed-in case too.

3. **Stop calling an unreadable proxy CA "not yet generated"** — the same conflation in a sibling check, found auditing the rest of the file. `checkCACert` folded every `os.Stat` error into the benign "not yet generated". Absence really is benign and stays ok; any other stat error goes red.

### Audit of the remaining checks in doctor_checks.go

| Check | Disposition |
|---|---|
| `checkClaudeAuth` | changed — the reported defect |
| `checkCACert` | changed — same conflation, wrong verdict for non-NotExist stat errors |
| `checkAgentSkills` | examined, unchanged — any stat error already goes red; only the remedy text is imprecise for a permission error, and the verdict is right |
| `checkCodenavIndex` | examined, unchanged — `store.Open` creates the database, so an absent index is not an error path |
| `checkTrackers`, `checkDocker`, `checkPersistence` | examined, unchanged — no filesystem reads |

`internal/pipelinefsm/pipeline-fsm.json` names no doctor check and no `claude-auth` state; this touches no stage or marker semantics, so the document is unchanged.

### Verification

`make check`: `fmt-check`, `lint`, `sec` (gosec 0 issues, govulncheck clean), `secrets` all green. Tests: 5362 run, one failure — `internal/claude TestTranscriptRoots_dropsNestedRoot`, which **fails identically on clean `main`** at 28e24ff2. It is a macOS-only `/private/var` vs `/var` symlink-resolution flake in a package this branch does not touch, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)