### PR TITLE
A run waiting on a subagent is judged idle and reaped after 3 minutes

### DIFF
--- a/docs/reaper.md
+++ b/docs/reaper.md
@@ -58,14 +58,24 @@ definition of "hung", and it is two numbers, not one:
 | Condition | Budget | Constant |
 | --- | --- | --- |
 | No outstanding work at all | **3 minutes** of silence | `IdleGrace` |
-| Inside a tool call **or** a model request in flight **or** the model-request state unknown | **30 minutes** of silence | `WorkingIdleGrace` |
+| Inside a tool call **or** waiting on a dispatched subagent **or** a model request in flight **or** the model-request state unknown | **30 minutes** of silence | `WorkingIdleGrace` |
 | Waiting on a human (`Notification` — a permission prompt) | **never stalls** | `Blocked` |
 
-Waiting on a local tool call and waiting on the model are the same thing from
-the outside — outstanding work, from two sources — so either earns the generous
-bound. Genuine idleness, with neither, gets the short one. A single fixed
-timeout was wrong in both directions at once: it killed running test suites and
-still made real hangs wait.
+Waiting on a local tool call, waiting on a subagent and waiting on the model
+are the same thing from the outside — outstanding work, from three sources — so
+any of them earns the generous bound. Genuine idleness, with none, gets the
+short one. A single fixed timeout was wrong in both directions at once: it
+killed running test suites and still made real hangs wait.
+
+The dispatch is counted rather than inferred. A subagent's hook events arrive
+under its PARENT's agent name, session and run id — nothing in the event
+separates them — so the subagent's own `PostToolUse` clears the parent's
+`InsideTool` and, before SC-4900, dropped a run that was waiting on a dispatch
+to the 3-minute budget. `AgentProgress.Subagents` counts the
+`SubagentStart`/`SubagentStop` brackets instead, as a depth, since a subagent
+may dispatch its own. A `SubagentStop` that never arrives leaves the generous
+budget in place until the run ends and the entry is dropped: the same safe
+direction unknown takes below.
 
 Unknown takes the generous bound deliberately. The machine must never kill live
 work because it lost its own bookkeeping — the same rule reconcile already

--- a/internal/claude/hookevents/parser.go
+++ b/internal/claude/hookevents/parser.go
@@ -43,7 +43,7 @@ func ApplyEvent(snap *SessionSnapshot, evt *Event) {
 		return
 	}
 	switch evt.EventName {
-	case "UserPromptSubmit", "SubagentStart":
+	case "UserPromptSubmit", EventSubagentStart:
 		snap.Status = logparser.StatusWorking
 		snap.ErrorType = ""
 		snap.CurrentTool = ""
@@ -62,7 +62,7 @@ func ApplyEvent(snap *SessionSnapshot, evt *Event) {
 		snap.BlockedTool = ""
 		snap.Status = logparser.StatusWorking
 
-	case EventStop, "SubagentStop":
+	case EventStop, EventSubagentStop:
 		// Stop after StopFailure keeps error visible.
 		if snap.Status != logparser.StatusError {
 			snap.Status = logparser.StatusReady

--- a/internal/claude/hookevents/types.go
+++ b/internal/claude/hookevents/types.go
@@ -22,6 +22,15 @@ const (
 	EventStopFailure = "StopFailure"
 )
 
+// The dispatch brackets. They are named for the same reason as the run-end
+// names: the daemon's liveness record reads them to know a parent is waiting
+// on a subagent (SC-4900), so a second package now has to agree with this one
+// on the spelling.
+const (
+	EventSubagentStart = "SubagentStart"
+	EventSubagentStop  = "SubagentStop"
+)
+
 // IsRunEnd reports whether an event name means the run ended, cleanly or not.
 // The three readers that used to spell the disjunction by hand are the reason
 // it exists: they must agree, and nothing made them.

--- a/internal/daemon/agentprogress.go
+++ b/internal/daemon/agentprogress.go
@@ -10,11 +10,11 @@ import (
 //
 // They are deliberately two numbers, not one rule with a single input: "no
 // event for N minutes" means something different depending on whether the
-// agent has outstanding work. Waiting on a local tool call and waiting on the
-// model are the same thing from the outside — outstanding work, from two
-// sources — so either one earns the generous bound; genuine idleness, with
-// neither, gets the short one and the short bound is finally telling the
-// truth (SC-3074).
+// agent has outstanding work. Waiting on a local tool call, waiting on a
+// dispatched subagent and waiting on the model are the same thing from the
+// outside — outstanding work, from three sources — so any one of them earns
+// the generous bound; genuine idleness, with none, gets the short one and the
+// short bound is finally telling the truth (SC-3074, SC-4900).
 //
 // A single fixed timeout cannot serve both, which is exactly why the wall-clock
 // grace it replaces was wrong in both directions at once.
@@ -22,7 +22,8 @@ var (
 	// IdleGrace bounds silence when the agent has no outstanding work at all.
 	IdleGrace = 3 * time.Minute
 	// WorkingIdleGrace bounds silence while the agent has outstanding work —
-	// inside a tool call or waiting on a model response. Generous on purpose:
+	// inside a tool call, waiting on a subagent, or waiting on a model
+	// response. Generous on purpose:
 	// killing a running suite, or a run composing a long answer, is far worse
 	// than noticing a genuine hang a few minutes later.
 	WorkingIdleGrace = 30 * time.Minute
@@ -93,18 +94,27 @@ type AgentProgress struct {
 	// Blocked reports the agent is waiting on a human (a permission prompt).
 	// That is neither progress nor a hang — it needs an answer, not a retry.
 	Blocked bool
+	// Subagents is how many dispatches this agent is waiting on. It is counted
+	// rather than derived from InsideTool because a subagent's hook events
+	// carry its PARENT's agent name, session and run id — nothing in the event
+	// separates them — so the subagent's own PostToolUse erases the parent's
+	// record of being inside the Agent call that spawned it. Counting the
+	// SubagentStart/SubagentStop brackets keeps the parent's outstanding work
+	// visible for exactly as long as it is outstanding (SC-4900).
+	Subagents int
 }
 
-// hasOutstandingWork reports whether the agent has work in flight of either
-// kind — a local tool call or a request to the model — that no event can
-// arrive to signal until it completes (SC-3074).
+// hasOutstandingWork reports whether the agent has work in flight of any of
+// three kinds — a local tool call, a request to the model, or a subagent it
+// dispatched — that no event can arrive to signal until it completes (SC-3074,
+// SC-4900).
 //
 // An UNKNOWN model-request state counts as work in flight. That is the same
 // rule stageStalled states for the other input: absent evidence is never read
 // as evidence of death, because killing live work on a bookkeeping failure is
 // the one direction this must never fail in (SC-3853).
 func (p AgentProgress) hasOutstandingWork() bool {
-	return p.InsideTool || p.ModelRequest != ModelRequestNone
+	return p.InsideTool || p.Subagents > 0 || p.ModelRequest != ModelRequestNone
 }
 
 // IdleBudget is how long this agent may stay silent before it counts as hung.
@@ -169,6 +179,22 @@ func trackProgress(progress map[string]AgentProgress, evt hookevents.Event) {
 	case "PostToolUse":
 		p.InsideTool = false
 		p.Tool = ""
+		p.Blocked = false
+	case hookevents.EventSubagentStart:
+		// The parent is now inside a dispatch whose only other sign of life is
+		// the subagent's own events — which arrive under the parent's name and
+		// would otherwise clear InsideTool. Depth, not a flag: a subagent may
+		// dispatch its own.
+		p.Subagents++
+		p.Blocked = false
+	case hookevents.EventSubagentStop:
+		// Floored because a dropped Stop must not push the count negative and
+		// silently cancel a later dispatch. A Stop that never arrives leaves
+		// the generous budget in place until the run ends and the entry is
+		// dropped — the safe direction, the same one SC-3853 chose.
+		if p.Subagents > 0 {
+			p.Subagents--
+		}
 		p.Blocked = false
 	case "Notification":
 		// Claude is asking for permission: the agent is waiting on a human.

--- a/internal/daemon/agentprogress_test.go
+++ b/internal/daemon/agentprogress_test.go
@@ -186,3 +186,100 @@ func TestHookEventStore_UnknownAgentIsNotKnown(t *testing.T) {
 	_, ok := s.AgentProgress("board-SC-9-planning")
 	require.False(t, ok)
 }
+
+// The SC-4900 regression, replayed from board-SC-4820-implementation run
+// 97ffc408: a subagent's tool events arrive under the PARENT's agent name, so
+// the subagent's last PostToolUse used to clear InsideTool and drop a run that
+// was waiting on a dispatch to the 3-minute budget. It was killed at 3m4s,
+// three times, always at the planning subagent's last tool call.
+func TestAgentProgress_WaitingOnASubagentIsNotIdle(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	const agent = "board-SC-4820-implementation"
+
+	trackProgress(progress, evt("PreToolUse", agent, "Agent", start))
+	trackProgress(progress, evt(hookevents.EventSubagentStart, agent, "", start.Add(time.Second)))
+	// The subagent works for ten minutes under its parent's name.
+	last := start.Add(10 * time.Minute)
+	trackProgress(progress, evt("PreToolUse", agent, "Bash", last.Add(-time.Second)))
+	trackProgress(progress, evt("PostToolUse", agent, "Bash", last))
+
+	p := progress[agent]
+	p.ModelRequest = ModelRequestNone // the proxy answered: nothing open right now
+	require.False(t, p.InsideTool, "the subagent's own tool call did finish")
+	require.Equal(t, 1, p.Subagents, "but the dispatch it belongs to has not")
+	require.Equal(t, WorkingIdleGrace, p.IdleBudget())
+
+	stalled, _ := p.Stalled(last.Add(3*time.Minute + 4*time.Second))
+	require.False(t, stalled, "the exact idle that killed the SC-4820 runs")
+
+	stalled, _ = p.Stalled(last.Add(WorkingIdleGrace + time.Minute))
+	require.True(t, stalled, "a dispatch that never returns is still a hang, later")
+}
+
+// The dispatch brackets close: once the subagent returns, the parent is
+// thinking between tool calls again and the short budget is the honest one.
+func TestAgentProgress_ReturnedSubagentRestoresTheShortBudget(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	const agent = "a"
+
+	trackProgress(progress, evt("PreToolUse", agent, "Agent", start))
+	trackProgress(progress, evt(hookevents.EventSubagentStart, agent, "", start.Add(time.Second)))
+	trackProgress(progress, evt(hookevents.EventSubagentStop, agent, "", start.Add(2*time.Minute)))
+	trackProgress(progress, evt("PostToolUse", agent, "Agent", start.Add(2*time.Minute+time.Second)))
+
+	p := progress[agent]
+	p.ModelRequest = ModelRequestNone
+	require.Equal(t, 0, p.Subagents)
+	require.Equal(t, IdleGrace, p.IdleBudget())
+}
+
+// A subagent may dispatch its own, and every bracket arrives under the same
+// name — so the count is a depth, not a flag. An inner return must not report
+// the outer dispatch as finished.
+func TestAgentProgress_NestedSubagentsCountAsDepth(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	const agent = "a"
+
+	trackProgress(progress, evt(hookevents.EventSubagentStart, agent, "", start))
+	trackProgress(progress, evt(hookevents.EventSubagentStart, agent, "", start.Add(time.Second)))
+	trackProgress(progress, evt(hookevents.EventSubagentStop, agent, "", start.Add(2*time.Second)))
+
+	p := progress[agent]
+	p.ModelRequest = ModelRequestNone
+	require.Equal(t, 1, p.Subagents, "the outer dispatch is still outstanding")
+	require.Equal(t, WorkingIdleGrace, p.IdleBudget())
+}
+
+// A Stop that never arrives must not push the count below zero, where a later
+// dispatch would be cancelled by a bracket that had already closed.
+func TestAgentProgress_UnpairedSubagentStopFloorsAtZero(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	const agent = "a"
+
+	trackProgress(progress, evt(hookevents.EventSubagentStop, agent, "", start))
+	require.Equal(t, 0, progress[agent].Subagents)
+
+	trackProgress(progress, evt(hookevents.EventSubagentStart, agent, "", start.Add(time.Second)))
+	p := progress[agent]
+	p.ModelRequest = ModelRequestNone
+	require.Equal(t, 1, p.Subagents, "the next dispatch still counts")
+	require.Equal(t, WorkingIdleGrace, p.IdleBudget())
+}
+
+// A run that ends drops its entry, so a dispatch left outstanding by a kill
+// cannot outlive the run and hold the generous budget open for the relaunch.
+func TestAgentProgress_RunEndClearsAnOutstandingSubagent(t *testing.T) {
+	progress := map[string]AgentProgress{}
+	start := time.Unix(1000, 0)
+	const agent = "a"
+
+	trackProgress(progress, evt(hookevents.EventSubagentStart, agent, "", start))
+	trackProgress(progress, evt(hookevents.EventStopFailure, agent, "", start.Add(time.Minute)))
+
+	_, ok := progress[agent]
+	require.False(t, ok)
+}

--- a/internal/daemon/board_failure.go
+++ b/internal/daemon/board_failure.go
@@ -949,9 +949,11 @@ const MaxSilenceReaps = 3
 // must not leave a reader guessing between a crash, a kill, and a restart
 // (SC-2447's third and fourth wanted outcomes). "no outstanding model
 // request" names the SC-3074 signal directly, replacing the disproven
-// transcript-output heuristic in the sentence.
+// transcript-output heuristic in the sentence, and the dispatch clause names
+// the third input the budget reads (SC-4900) — a reader who knows a subagent
+// was running would otherwise take this line for a lie.
 func silenceReapReason(idle string) string {
-	return "the daemon observed " + idle + " with no sign of life — no tool activity and no outstanding " +
+	return "the daemon observed " + idle + " with no sign of life — no tool activity, no subagent running and no outstanding " +
 		"model request — past the idle budget, and stopped the stage. This is a " + silenceReapSentinel + ", not a stage " +
 		"failure, so it is not charged against the retry budget. The stage was relaunched automatically."
 }

--- a/internal/daemon/fsm_where.go
+++ b/internal/daemon/fsm_where.go
@@ -82,12 +82,16 @@ type WhereAgent struct {
 	// Known is false when the daemon has no record — it restarted, or the agent
 	// has yet to emit anything. Reported rather than folded into "not alive",
 	// because absent evidence and evidence of absence lead to opposite actions.
-	Known           bool   `json:"known"`
-	LastEventAt     string `json:"last_event_at,omitempty"`
-	IdleSeconds     int    `json:"idle_seconds,omitempty"`
-	Stalled         bool   `json:"stalled"`
-	InsideTool      bool   `json:"inside_tool,omitempty"`
-	OutstandingCall bool   `json:"outstanding_model_request,omitempty"`
+	Known       bool   `json:"known"`
+	LastEventAt string `json:"last_event_at,omitempty"`
+	IdleSeconds int    `json:"idle_seconds,omitempty"`
+	Stalled     bool   `json:"stalled"`
+	InsideTool  bool   `json:"inside_tool,omitempty"`
+	// Subagents explains a generous budget that inside_tool and model_request
+	// alone cannot: a run waiting on a dispatch is working, and a reader
+	// otherwise sees an idle-looking agent the machine declines to reap.
+	Subagents       int  `json:"subagents,omitempty"`
+	OutstandingCall bool `json:"outstanding_model_request,omitempty"`
 	// ModelRequest is the same signal with its third answer visible: "open",
 	// "none", or "unknown" — the daemon could not resolve this agent's
 	// connections and so cannot say. Reported because a run reaped while
@@ -387,6 +391,7 @@ func whereAgent(key string, card BoardCard, deps WhereDeps) *WhereAgent {
 		IdleSeconds:     int(idle.Seconds()),
 		Stalled:         stalled,
 		InsideTool:      p.InsideTool,
+		Subagents:       p.Subagents,
 		OutstandingCall: p.ModelRequest == ModelRequestOpen,
 		ModelRequest:    p.ModelRequest.String(),
 		Blocked:         p.Blocked,

--- a/internal/pipelinefsm/pipeline-fsm.json
+++ b/internal/pipelinefsm/pipeline-fsm.json
@@ -1207,7 +1207,7 @@
       "BoardReconcileInterval": "2m, jittered ±50% — how often the durable pass re-scans open cards (internal/daemon/board_reconcile.go)",
       "StuckRunningGrace": "15m — how long a running card is left alone before liveness is judged",
       "IdleGrace": "3m — how long an agent with NO outstanding work may stay silent before the reap (internal/daemon/agentprogress.go)",
-      "WorkingIdleGrace": "30m — how long an agent with outstanding work may stay silent: inside a tool call, a model request open, OR the model-request state unknown. Unknown takes the generous bound on purpose — the machine must not kill live work because it lost its own bookkeeping (SC-3853).",
+      "WorkingIdleGrace": "30m — how long an agent with outstanding work may stay silent: inside a tool call, waiting on a dispatched subagent, a model request open, OR the model-request state unknown. A dispatch counts because a subagent's events arrive under its parent's name and used to be read as the parent finishing its own work (SC-4900). Unknown takes the generous bound on purpose — the machine must not kill live work because it lost its own bookkeeping (SC-3853).",
       "QueuedLaunchGrace": "2m — how long a card whose decision was answered may sit unstarted before the machine starts it (internal/daemon/board_reconcile_queued.go). Short because the launch is the same call that recorded the choice; it exists only so a tick landing inside that call does not race it.",
       "DefaultStageRetries": "2 — automatic in-place relaunches of one stage (internal/daemon/board_retry.go)",
       "DefaultPRReviewRounds": "3 — review→fix rounds before the loop escalates (internal/daemon/pr_review_loop.go)",


### PR DESCRIPTION
PM ticket: SC-4900
Branch: fix-subagent-liveness
